### PR TITLE
Fix username field retrieval

### DIFF
--- a/src/telegramApi.ml
+++ b/src/telegramApi.ml
@@ -26,7 +26,7 @@ module User = struct
     let id = the_int @@ get_field "id" obj in
     let first_name = the_string @@ get_field "first_name" obj in
     let last_name = the_string <$> get_opt_field "last_name" obj in
-    let username = the_string <$> get_opt_field "last_name" obj in
+    let username = the_string <$> get_opt_field "username" obj in
     create ~id ~first_name ~last_name ~username ()
 end
 

--- a/src/telegramApi.ml
+++ b/src/telegramApi.ml
@@ -2068,7 +2068,8 @@ module Mk (B : BOT) = struct
   let rec pop_update ?(run_cmds=true) () =
     let open Update in
     let json = `Assoc [("offset", `Int !offset);
-                       ("limit", `Int 1)] in
+                       ("limit", `Int 1);
+                       ("timeout", `Int 30)] in
     let body = Yojson.Safe.to_string json in
     let headers = Cohttp.Header.init_with "Content-Type" "application/json" in
     Client.post ~headers ~body:(Cohttp_lwt_body.of_string body) (Uri.of_string (url ^ "getUpdates")) >>= fun (resp, body) ->


### PR DESCRIPTION
There was a mistake when filling the `User.username` field. The 'last_name' field of the message was copied instead of the 'username' one.