### PR TITLE
Add missing dependencies to generated `opam` file

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -11,4 +11,14 @@
  (name telegraml)
  (synopsis "Telegram Bot API bindings for OCaml")
  (documentation https://github.com/nv-vn/telegraml)
- (depends alcotest fmt logs))
+ (depends
+   alcotest
+   batteries
+   cohttp
+   cohttp-lwt
+   cohttp-lwt-unix
+   fmt
+   logs
+   lwt
+   uri
+   (yojson (>= "1.6.0"))))

--- a/telegraml.opam
+++ b/telegraml.opam
@@ -9,8 +9,15 @@ bug-reports: "https://github.com/nv-vn/telegraml/issues"
 depends: [
   "dune" {>= "2.0"}
   "alcotest"
+  "batteries"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
   "fmt"
   "logs"
+  "lwt"
+  "uri"
+  "yojson" {>= "1.6.0"}
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
There was a number of packages missing from the dependencies, like a new-enough Yojson, Cohttp, Batteries and Lwt, so this PR adds them.